### PR TITLE
[DEVPASS] [FIX] Use array contains instead of indexes

### DIFF
--- a/solutions/devsprint-bruno-ramos-2/DeliveryAppChallengeTests/Modules/Product/RestaurantList/RestaurantListInteractorTests.swift
+++ b/solutions/devsprint-bruno-ramos-2/DeliveryAppChallengeTests/Modules/Product/RestaurantList/RestaurantListInteractorTests.swift
@@ -31,8 +31,8 @@ class RestaurantListInteractorTests: XCTestCase {
         switch presenterSpy.presentFetchedRestaurantListResponsePassed {
         case .success(let restaurantList):
             XCTAssertNotNil(restaurantList)
-            XCTAssertEqual(restaurantList[0].name, "Padaria Bolo Fofo")
-            XCTAssertEqual(restaurantList[1].name, "Baita Padaria")
+            XCTAssertTrue(restaurantList.contains { $0.name == "Padaria Bolo Fofo" })
+            XCTAssertTrue(restaurantList.contains { $0.name == "Baita Padaria" })
         default:
             XCTFail("Should be a success result.")
         }

--- a/solutions/devsprint-bruno-ramos-2/DeliveryAppChallengeTests/Modules/Product/RestaurantList/ResturantListWorkerTests.swift
+++ b/solutions/devsprint-bruno-ramos-2/DeliveryAppChallengeTests/Modules/Product/RestaurantList/ResturantListWorkerTests.swift
@@ -36,8 +36,8 @@ final class RestaurantListWorkerTests: XCTestCase {
         XCTAssertNotNil(result)
         
         let restaurantList = try XCTUnwrap(result?.get())
-        XCTAssertEqual(restaurantList[0].name, "Padaria Bolo Fofo")
-        XCTAssertEqual(restaurantList[1].name, "Baita Padaria")
+        XCTAssertTrue(restaurantList.contains { $0.name == "Padaria Bolo Fofo" })
+        XCTAssertTrue(restaurantList.contains { $0.name == "Baita Padaria" })
     }
     
     func test_fetchRestaurantList_givenFailureResponse_shouldFail() throws {


### PR DESCRIPTION
## Informações:

Correção de testes unitários para usar o método contains ao invés de índices.